### PR TITLE
feat: get oa dns records

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
+    "@govtechsg/dnsprove": "^2.1.1",
     "@govtechsg/oa-verify": "^7.0.0",
     "@govtechsg/open-attestation": "^4.2.1",
     "react": "^16.13.1",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react";
 import { BrowserRouter, Route, Switch, Link } from "react-router-dom";
 import { Breadcrumb } from "./components/Breadcrumb/Breadcrumb";
 import oaLogo from "./images/oa.svg";
+import { Dns } from "./views/Dns/Dns";
 import { Home } from "./views/Home";
 import { Verify } from "./views/Verify/Verify";
 import { Wrap } from "./views/Wrap/Wrap";
@@ -52,6 +53,9 @@ export const Router = (): ReactElement => {
             </Route>
             <Route exact path="/verify">
               <Verify />
+            </Route>
+            <Route exact path="/dns">
+              <Dns />
             </Route>
             <Route path="/">
               <Home />

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export const FailedAlert: React.FunctionComponent = ({ children }) => (
+  <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+    <strong className="font-bold">{children}</strong>
+  </div>
+);
+
+export const SucceedAlert: React.FunctionComponent = ({ children }) => (
+  <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
+    <strong className="font-bold">{children}</strong>
+  </div>
+);

--- a/src/views/Dns/Dns.tsx
+++ b/src/views/Dns/Dns.tsx
@@ -1,0 +1,90 @@
+import {
+  getDocumentStoreRecords,
+  getDnsDidRecords,
+  OpenAttestationDNSTextRecord,
+  OpenAttestationDnsDidRecord,
+} from "@govtechsg/dnsprove";
+import React, { useEffect, useState } from "react";
+import { FailedAlert, SucceedAlert } from "./../../components/Alert/Alert";
+
+enum Status {
+  INITIAL = "INITIAL",
+  SUCCEED = "SUCCEED",
+  FAILED = "FAILED",
+}
+
+export const Dns: React.FunctionComponent = () => {
+  const [location, setLocation] = useState("");
+  const [status, setStatus] = useState<Status>(Status.INITIAL);
+  const [recordsDid, setRecordsDid] = useState<OpenAttestationDnsDidRecord[]>([]);
+  const [recordsText, setRecordsTxt] = useState<OpenAttestationDNSTextRecord[]>([]);
+
+  useEffect(() => {
+    setStatus(Status.INITIAL);
+  }, [location]);
+
+  const getRecords = async (): Promise<void> => {
+    try {
+      const dnsDidRecords = await getDnsDidRecords(location);
+      const dnsTextRecords = await getDocumentStoreRecords(location);
+      setRecordsDid(dnsDidRecords);
+      setRecordsTxt(dnsTextRecords);
+      console.log(dnsDidRecords, dnsTextRecords);
+      setStatus(Status.SUCCEED);
+    } catch (e) {
+      setStatus(Status.FAILED);
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-3xl mb-4">Get OpenAttestation DNS TXT records</h1>
+      <input
+        className="w-full px-3 py-2 text-gray-800 border-2 rounded-lg focus:shadow-outline mb-2"
+        onChange={(e) => setLocation(e.target.value)}
+        placeholder="example.tradetrust.io"
+        value={location}
+      />
+      <button
+        className="btn-primary"
+        onClick={() => {
+          getRecords();
+        }}
+      >
+        Get Records
+      </button>
+      {status === Status.SUCCEED && (
+        <>
+          {recordsDid.length === 0 && recordsText.length === 0 && location.length !== 0 ? (
+            <FailedAlert>
+              Did you enter the right DNS? Is there OpenAttestation TXT records created on{" "}
+              <span className="text-red-400">{location}</span>?
+            </FailedAlert>
+          ) : (
+            <SucceedAlert>Total {[...recordsDid, ...recordsText].length} record(s) found.</SucceedAlert>
+          )}
+          {recordsDid && (
+            <div className="my-8">
+              <h3 className="font-bold">DNS DID records</h3>
+              <p>{recordsDid.length} record(s) found.</p>
+              <pre className="mt-2 text-left bg-white border-2 border-teal-600 whitespace-pre-wrap">
+                {JSON.stringify(recordsDid, null, 2)}
+              </pre>
+            </div>
+          )}
+          {recordsText && (
+            <div className="my-8">
+              <h3 className="font-bold">DNS TXT records</h3>
+              <p>{recordsText.length} record(s) found.</p>
+              <pre className="mt-2 text-left bg-white border-2 border-teal-600 whitespace-pre-wrap">
+                {JSON.stringify(recordsText, null, 2)}
+              </pre>
+            </div>
+          )}
+        </>
+      )}
+      {status === Status.FAILED && <FailedAlert>Get records failed</FailedAlert>}
+    </div>
+  );
+};

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -18,5 +18,6 @@ export const Home: React.FunctionComponent = () => (
   <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 container mx-auto">
     <Tool title="(un)Wrap" to="/wrap" />
     <Tool title="Verify" to="/verify" />
+    <Tool title="Dns" to="/dns" />
   </div>
 );

--- a/src/views/Verify/Verify.tsx
+++ b/src/views/Verify/Verify.tsx
@@ -1,17 +1,6 @@
 import { verificationBuilder, VerificationFragment, openAttestationVerifiers, isValid } from "@govtechsg/oa-verify";
 import React, { useEffect, useState } from "react";
-
-const FailedAlert: React.FunctionComponent = ({ children }) => (
-  <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
-    <strong className="font-bold">{children}</strong>
-  </div>
-);
-
-const SucceedAlert: React.FunctionComponent = ({ children }) => (
-  <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
-    <strong className="font-bold">{children}</strong>
-  </div>
-);
+import { FailedAlert, SucceedAlert } from "./../../components/Alert/Alert";
 
 type Status = "INITIAL" | "PENDING" | "SUCCEED" | "FAILED";
 type Network = "ropsten" | "homestead" | "rinkeby";

--- a/src/views/Wrap/Wrap.tsx
+++ b/src/views/Wrap/Wrap.tsx
@@ -1,17 +1,6 @@
 import { getData, wrapDocument } from "@govtechsg/open-attestation";
 import React, { useEffect, useState } from "react";
-
-const FailedAlert: React.FunctionComponent = ({ children }) => (
-  <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
-    <strong className="font-bold">{children}</strong>
-  </div>
-);
-
-const SucceedAlert: React.FunctionComponent = ({ children }) => (
-  <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
-    <strong className="font-bold">{children}</strong>
-  </div>
-);
+import { FailedAlert, SucceedAlert } from "./../../components/Alert/Alert";
 
 type Status = "INITIAL" | "SUCCEED" | "FAILED";
 export const Wrap: React.FunctionComponent = () => {


### PR DESCRIPTION
### why?

- keep issuing onto wrong address, to debug need to double check on dns if doc store/token registry address is correct + there
- find it slow to use oa cli (keep forgeting the command also)

maybe i can...
- do it as an alias to cli command for own com (only benefit myself)
- create an basic UI oa tool, since we already had the library (benefit all)

![Screenshot 2021-03-10 at 4 14 56 PM](https://user-images.githubusercontent.com/4774314/110598263-83ccbd80-81bc-11eb-8be3-d9461b38fa3c.png)
