### PR TITLE
fix: update oa

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1843,16 +1843,6 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==",
       "dev": true
     },
-    "@digitalbazaar/http-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.2.0.tgz",
-      "integrity": "sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==",
-      "requires": {
-        "esm": "^3.2.22",
-        "ky": "^0.25.1",
-        "ky-universal": "^0.8.2"
-      }
-    },
     "@emotion/babel-plugin": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
@@ -2776,404 +2766,29 @@
       }
     },
     "@govtechsg/open-attestation": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@govtechsg/open-attestation/-/open-attestation-6.0.4.tgz",
-      "integrity": "sha512-UFwp9EiyW8eZNCuvxQNhxuKN6Sm9jTnkHauNNfdGiL8TnfEKiBIFnEJBgRwTazhRcjVtRdq7C5W5VnKRB2PUIg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@govtechsg/open-attestation/-/open-attestation-6.5.1.tgz",
+      "integrity": "sha512-rId128iZSh9sUGhBfp6sPFNxGkP7BIKlu4gIXcnGTQ6NDsPipvfuoog2Y6y4ny3Q+XFtXQJUkWxHYT0YctCd0w==",
       "requires": {
+        "@govtechsg/jsonld": "^0.1.0",
         "ajv": "^8.6.2",
         "ajv-formats": "^2.1.0",
-        "cross-fetch": "^3.1.4",
+        "cross-fetch": "^3.1.5",
         "debug": "^4.3.2",
         "ethers": "^5.4.3",
         "flatley": "^5.2.0",
         "js-base64": "^3.6.1",
         "js-sha3": "^0.8.0",
-        "jsonld": "^5.2.0",
         "lodash": "^4.17.21",
         "runtypes": "^6.3.2",
         "uuid": "^8.3.2",
-        "validator": "^13.6.0"
+        "validator": "^13.7.0"
       },
       "dependencies": {
-        "@ethersproject/abi": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.1.tgz",
-          "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
-          "requires": {
-            "@ethersproject/address": "^5.4.0",
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/constants": "^5.4.0",
-            "@ethersproject/hash": "^5.4.0",
-            "@ethersproject/keccak256": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/strings": "^5.4.0"
-          }
-        },
-        "@ethersproject/abstract-provider": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
-          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/networks": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/transactions": "^5.4.0",
-            "@ethersproject/web": "^5.4.0"
-          }
-        },
-        "@ethersproject/abstract-signer": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
-          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.4.0",
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0"
-          }
-        },
-        "@ethersproject/address": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
-          "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/keccak256": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/rlp": "^5.4.0"
-          }
-        },
-        "@ethersproject/base64": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
-          "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0"
-          }
-        },
-        "@ethersproject/basex": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
-          "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
-          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "bn.js": "^4.11.9"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
-          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
-          "requires": {
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/constants": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
-          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.4.0"
-          }
-        },
-        "@ethersproject/contracts": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.1.tgz",
-          "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
-          "requires": {
-            "@ethersproject/abi": "^5.4.0",
-            "@ethersproject/abstract-provider": "^5.4.0",
-            "@ethersproject/abstract-signer": "^5.4.0",
-            "@ethersproject/address": "^5.4.0",
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/constants": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/transactions": "^5.4.0"
-          }
-        },
-        "@ethersproject/hash": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
-          "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.4.0",
-            "@ethersproject/address": "^5.4.0",
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/keccak256": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/strings": "^5.4.0"
-          }
-        },
-        "@ethersproject/hdnode": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
-          "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.4.0",
-            "@ethersproject/basex": "^5.4.0",
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/pbkdf2": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/sha2": "^5.4.0",
-            "@ethersproject/signing-key": "^5.4.0",
-            "@ethersproject/strings": "^5.4.0",
-            "@ethersproject/transactions": "^5.4.0",
-            "@ethersproject/wordlists": "^5.4.0"
-          }
-        },
-        "@ethersproject/json-wallets": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
-          "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.4.0",
-            "@ethersproject/address": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/hdnode": "^5.4.0",
-            "@ethersproject/keccak256": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/pbkdf2": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/random": "^5.4.0",
-            "@ethersproject/strings": "^5.4.0",
-            "@ethersproject/transactions": "^5.4.0",
-            "aes-js": "3.0.0",
-            "scrypt-js": "3.0.1"
-          }
-        },
-        "@ethersproject/keccak256": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
-          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "js-sha3": "0.5.7"
-          },
-          "dependencies": {
-            "js-sha3": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-            }
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
-          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A=="
-        },
-        "@ethersproject/networks": {
-          "version": "5.4.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
-          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
-          "requires": {
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/pbkdf2": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
-          "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/sha2": "^5.4.0"
-          }
-        },
-        "@ethersproject/properties": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
-          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
-          "requires": {
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/providers": {
-          "version": "5.4.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.5.tgz",
-          "integrity": "sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.4.0",
-            "@ethersproject/abstract-signer": "^5.4.0",
-            "@ethersproject/address": "^5.4.0",
-            "@ethersproject/basex": "^5.4.0",
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/constants": "^5.4.0",
-            "@ethersproject/hash": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/networks": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/random": "^5.4.0",
-            "@ethersproject/rlp": "^5.4.0",
-            "@ethersproject/sha2": "^5.4.0",
-            "@ethersproject/strings": "^5.4.0",
-            "@ethersproject/transactions": "^5.4.0",
-            "@ethersproject/web": "^5.4.0",
-            "bech32": "1.1.4",
-            "ws": "7.4.6"
-          }
-        },
-        "@ethersproject/random": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
-          "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/rlp": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
-          "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/sha2": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
-          "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "hash.js": "1.1.7"
-          }
-        },
-        "@ethersproject/signing-key": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
-          "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "bn.js": "^4.11.9",
-            "elliptic": "6.5.4",
-            "hash.js": "1.1.7"
-          }
-        },
-        "@ethersproject/solidity": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
-          "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/keccak256": "^5.4.0",
-            "@ethersproject/sha2": "^5.4.0",
-            "@ethersproject/strings": "^5.4.0"
-          }
-        },
-        "@ethersproject/strings": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
-          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/constants": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
-          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
-          "requires": {
-            "@ethersproject/address": "^5.4.0",
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/constants": "^5.4.0",
-            "@ethersproject/keccak256": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/rlp": "^5.4.0",
-            "@ethersproject/signing-key": "^5.4.0"
-          }
-        },
-        "@ethersproject/units": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
-          "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/constants": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/wallet": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
-          "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.4.0",
-            "@ethersproject/abstract-signer": "^5.4.0",
-            "@ethersproject/address": "^5.4.0",
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/hash": "^5.4.0",
-            "@ethersproject/hdnode": "^5.4.0",
-            "@ethersproject/json-wallets": "^5.4.0",
-            "@ethersproject/keccak256": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/random": "^5.4.0",
-            "@ethersproject/signing-key": "^5.4.0",
-            "@ethersproject/transactions": "^5.4.0",
-            "@ethersproject/wordlists": "^5.4.0"
-          }
-        },
-        "@ethersproject/web": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
-          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
-          "requires": {
-            "@ethersproject/base64": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/strings": "^5.4.0"
-          }
-        },
-        "@ethersproject/wordlists": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
-          "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/hash": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/strings": "^5.4.0"
-          }
-        },
         "ajv": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -3181,60 +2796,58 @@
             "uri-js": "^4.2.2"
           }
         },
+        "cross-fetch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+          "requires": {
+            "node-fetch": "2.6.7"
+          }
+        },
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
         },
-        "ethers": {
-          "version": "5.4.6",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.6.tgz",
-          "integrity": "sha512-F7LXARyB/Px3AQC6/QKedWZ8eqCkgOLORqL4B/F0Mag/K+qJSFGqsR36EaOZ6fKg3ZonI+pdbhb4A8Knt/43jQ==",
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
           "requires": {
-            "@ethersproject/abi": "5.4.1",
-            "@ethersproject/abstract-provider": "5.4.1",
-            "@ethersproject/abstract-signer": "5.4.1",
-            "@ethersproject/address": "5.4.0",
-            "@ethersproject/base64": "5.4.0",
-            "@ethersproject/basex": "5.4.0",
-            "@ethersproject/bignumber": "5.4.1",
-            "@ethersproject/bytes": "5.4.0",
-            "@ethersproject/constants": "5.4.0",
-            "@ethersproject/contracts": "5.4.1",
-            "@ethersproject/hash": "5.4.0",
-            "@ethersproject/hdnode": "5.4.0",
-            "@ethersproject/json-wallets": "5.4.0",
-            "@ethersproject/keccak256": "5.4.0",
-            "@ethersproject/logger": "5.4.1",
-            "@ethersproject/networks": "5.4.2",
-            "@ethersproject/pbkdf2": "5.4.0",
-            "@ethersproject/properties": "5.4.1",
-            "@ethersproject/providers": "5.4.5",
-            "@ethersproject/random": "5.4.0",
-            "@ethersproject/rlp": "5.4.0",
-            "@ethersproject/sha2": "5.4.0",
-            "@ethersproject/signing-key": "5.4.0",
-            "@ethersproject/solidity": "5.4.0",
-            "@ethersproject/strings": "5.4.0",
-            "@ethersproject/transactions": "5.4.0",
-            "@ethersproject/units": "5.4.0",
-            "@ethersproject/wallet": "5.4.0",
-            "@ethersproject/web": "5.4.0",
-            "@ethersproject/wordlists": "5.4.0"
+            "whatwg-url": "^5.0.0"
           }
         },
         "runtypes": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.4.0.tgz",
-          "integrity": "sha512-WHFztoMVkZ3+KK9qPTAox9xUW1IqihItKsjLMKzGsY89EkEMSPsYV5mubz/Fkg27tt4zRm+fT+wKiuX2/3PfLQ=="
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.5.1.tgz",
+          "integrity": "sha512-vYxcAYzC868ZY4BgazBomT9dpWHZnG3CH++5mhlVKGKqf2MzON4itmEmQt3uGTUOyipeUn7GALAN0nQhjPNRtA=="
         },
-        "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "validator": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+          "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -9717,7 +9330,7 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -11376,11 +10989,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "data-urls": {
       "version": "2.0.0",
@@ -13307,11 +12915,6 @@
         }
       }
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -14020,11 +13623,6 @@
           "dev": true
         }
       }
-    },
-    "fetch-blob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
-      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow=="
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -18855,17 +18453,6 @@
         "universalify": "^2.0.0"
       }
     },
-    "jsonld": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz",
-      "integrity": "sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==",
-      "requires": {
-        "@digitalbazaar/http-client": "^1.1.0",
-        "canonicalize": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "rdf-canonize": "^3.0.0"
-      }
-    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -18941,31 +18528,6 @@
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
       "dev": true
-    },
-    "ky": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
-      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA=="
-    },
-    "ky-universal": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
-      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "3.0.0-beta.9"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "3.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
-          "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
-          "requires": {
-            "data-uri-to-buffer": "^3.0.1",
-            "fetch-blob": "^2.1.1"
-          }
-        }
-      }
     },
     "language-subtag-registry": {
       "version": "0.3.21",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@govtechsg/dnsprove": "^2.1.3",
     "@govtechsg/oa-encryption": "^1.3.3",
     "@govtechsg/oa-verify": "^7.10.0",
-    "@govtechsg/open-attestation": "^6.0.4",
+    "@govtechsg/open-attestation": "^6.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
so that revocation type `OCSP_RESPONDER` is accepted for wrapping, from [v6.2.0](https://github.com/Open-Attestation/open-attestation/pull/208/files) onwards.