### PR TITLE
chore: update transient storage sample

### DIFF
--- a/src/views/encrypt-decrypt.tsx
+++ b/src/views/encrypt-decrypt.tsx
@@ -9,12 +9,12 @@ const SAMPLE = {
   q: {
     type: "DOCUMENT",
     payload: {
-      uri: "https://api-vaccine.storage.staging.notarise.io/document/c716022a-f3d0-43b5-bd53-bdd3aefe82c7",
+      uri: "https://api-vaccine.storage.staging.notarise.io/document/fd2fb343-dda5-44aa-9c34-9fb860061459",
       permittedActions: ["VIEW", "STORE"],
       redirect: "https://www.verify.gov.sg/verify",
     },
   },
-  anchor: { key: "af52904a968adfa2a66d2cb5f2bd076e1b395247c297d06bdc7760d48b0d3160" },
+  anchor: { key: "14b4f972d86511c2b9fc305e7148a49763243acb6225f919a1ff16dc056c8a14" },
 };
 
 const action = stringifyAndEncode(SAMPLE.q);

--- a/src/views/encrypt-decrypt.tsx
+++ b/src/views/encrypt-decrypt.tsx
@@ -9,12 +9,12 @@ const SAMPLE = {
   q: {
     type: "DOCUMENT",
     payload: {
-      uri: "https://api-vaccine.storage.staging.notarise.io/document/fd2fb343-dda5-44aa-9c34-9fb860061459",
+      uri: "https://api-vaccine.storage.staging.notarise.io/document/d0595f61-b493-4880-a748-f2de095405b1",
       permittedActions: ["VIEW", "STORE"],
       redirect: "https://www.verify.gov.sg/verify",
     },
   },
-  anchor: { key: "14b4f972d86511c2b9fc305e7148a49763243acb6225f919a1ff16dc056c8a14" },
+  anchor: { key: "ab8d3ff543ca89b775a559a6a3a92416ef971a16f7cbc38c0ce22488beff4b5f" },
 };
 
 const action = stringifyAndEncode(SAMPLE.q);


### PR DESCRIPTION
## Context
- fetched document should have not have "document" as a key. This additional field resulted in the toolkit not being able to decrypt and show the original document on the left text box
- Issue was was due to calling `POST` in transient storage API instead of getting queue number and then calling `PUT` document.

```JSON
{
"document": { // to remove this 
  "cipherText": "",
  "iv": "",
  "tag": "",
  "type": "",
  "ttl": "",
   },  
"key": ""
}
```

## What this PR does
- update transient storage document as the previous one was showing the wrong JSON structure (correct structure below)

```JSON
{
  "cipherText": "",
  "iv": "",
  "tag": "",
  "type": "",
  "ttl": "",
  "key": ""
} 
```