### PR TITLE
fix: bump @govtechsg/dnsprove from 2.5.0 to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-template",
       "version": "0.1.0",
       "dependencies": {
-        "@govtechsg/dnsprove": "^2.5.0",
+        "@govtechsg/dnsprove": "^2.6.1",
         "@govtechsg/oa-encryption": "^1.3.5",
         "@govtechsg/oa-verify": "^7.12.0",
         "@govtechsg/open-attestation": "^6.6.0",
@@ -3147,9 +3147,9 @@
       }
     },
     "node_modules/@govtechsg/dnsprove": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.5.0.tgz",
-      "integrity": "sha512-aUrLPF1DeydxKRJsLW++vQoTGXkUoP8zbHwaUU63vFar7pBZ/1UIWr/QJlYGmyVgZ++eQlHeKaiC+Zp3ix2Qag==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.6.1.tgz",
+      "integrity": "sha512-ALLe3EC9ix6ZsMIHgRRLdVYMC35yRShG8sRXb73D4bvw60Yz/pT/Y3e9w40KqG8HMMChvJaEMV6uQi6GR7Jwmw==",
       "dependencies": {
         "axios": "^0.21.1",
         "debug": "^4.3.1",
@@ -22752,9 +22752,9 @@
       }
     },
     "@govtechsg/dnsprove": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.5.0.tgz",
-      "integrity": "sha512-aUrLPF1DeydxKRJsLW++vQoTGXkUoP8zbHwaUU63vFar7pBZ/1UIWr/QJlYGmyVgZ++eQlHeKaiC+Zp3ix2Qag==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.6.1.tgz",
+      "integrity": "sha512-ALLe3EC9ix6ZsMIHgRRLdVYMC35yRShG8sRXb73D4bvw60Yz/pT/Y3e9w40KqG8HMMChvJaEMV6uQi6GR7Jwmw==",
       "requires": {
         "axios": "^0.21.1",
         "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@govtechsg/dnsprove": "^2.5.0",
+    "@govtechsg/dnsprove": "^2.6.1",
     "@govtechsg/oa-encryption": "^1.3.5",
     "@govtechsg/oa-verify": "^7.12.0",
     "@govtechsg/open-attestation": "^6.6.0",


### PR DESCRIPTION
## Context
DNS TXT records utilising netId 50 and 51 are not identified properly on Toolkit because `@govtechsg/dnsprove` is not updated to the latest version. XDC mainnet and testnet were added in Open-Attestation/dnsprove/pull/37

## What does this PR do?
- Bump `@govtechsg/dnsprove` from 2.5.0 to 2.6.1
- Fixes Open-Attestation/toolkit/issues/50